### PR TITLE
Add bioconda support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.10)
 
 project(cawlign)
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,11 @@ A standalone C++ port of `bealign`, a part of the `BioExt` (https://github.com/v
 
 #### Installation.
 
+`conda install -c bioconda cawlign`
+
+
+#### Building from source
+
 Requires `CMake`.
 
 ```


### PR DESCRIPTION
see https://github.com/bioconda/bioconda-recipes/pull/55168

this updates the readme to have bioconda instructions, and also bumps the min req for cmake from 3.0 to 3.10. that would let us make the bioconda recipe a bit simpler, which id like.

an outstanding possible todo: make INSTALL_PREFIX a bit more flexible.. bioconda wants to pass a prefix rather than use whatever was set in CMakeLists.txt here, and that was a little harder to do in the bioconda recipe than id have liked. that could be in this pr or another, or if the bioconda pr is approved as it is then maybe we dont need to change it here ever, depending what ppl prefer.

so all that to say, this pr represents i think the absolute minimum we should do to better support cawlign in bioconda, pending feedback on the recipe pr i linked above.